### PR TITLE
fix: set navbar logo height to 48

### DIFF
--- a/website/components/Navbar.vue
+++ b/website/components/Navbar.vue
@@ -9,7 +9,7 @@
             class="w-10 filter brightness-125"
             src="~/assets/logo-80x96.png?webp"
             width="40"
-            height="40"
+            height="48"
             alt="The Contender Tech logo, a blue whale spinning in a circle"
           />
           <p class="text-2xl text-gray-50 font-semibold tracking-wide">


### PR DESCRIPTION
This pull request adds:
- Explicit height of 48 for navbar logo