### PR TITLE
fix: hide overflow of hero content

### DIFF
--- a/website/components/HomeHero.vue
+++ b/website/components/HomeHero.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="hero" class="hero-bg">
+  <div id="hero" class="hero-bg overflow-hidden">
     <div
       id="content"
       class="flex flex-col sm:flex-row items-center container lg:max-w-5xl relative top-0 left-0 right-0 px-8 py-4 mx-auto"


### PR DESCRIPTION
This pull request adds:
- Class `overflow-hidden` to hero, removing horizontal scroll caused by absolutely-positioned image